### PR TITLE
Directly reference the args internal dict

### DIFF
--- a/nat_conntracker/__main__.py
+++ b/nat_conntracker/__main__.py
@@ -34,7 +34,7 @@ def main(sysargs=sys.argv[:]):
     parser = build_argument_parser(os.environ)
     args = parser.parse_args(sysargs[1:])
 
-    runner = build_runner(**dict(args))
+    runner = build_runner(**args.__dict__)
     runner.run()
     return 0
 


### PR DESCRIPTION
instead of attempting to cast via `dict()` as this breaks on (some?) versions of python2.7