### PR TITLE
Log hostnames when warning over threshold

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,12 @@
 import os
+import socket
 import sys
 
+import pytest
+
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+
+
+@pytest.fixture(autouse=True)
+def no_socket_gethostbyaddr(monkeypatch):
+    monkeypatch.setattr(socket, 'gethostbyaddr', lambda a: 'somehost')


### PR DESCRIPTION
Example log line from staging:

```
time=2018-03-08T21:48:02+0000 level=WARNING over threshold=50 src=10.20.0.4 dst=71.19.148.143:443 count=142 hostname=travis-job-ba212003-d61e-4ccb-993c-8abe5a10a47c.c.travis-staging-1.internal
```